### PR TITLE
Implement ACE vehicle locking

### DIFF
--- a/FNF_MissionTemplate.VR/client/loadout/fn_addItems.sqf
+++ b/FNF_MissionTemplate.VR/client/loadout/fn_addItems.sqf
@@ -39,3 +39,25 @@ if (pRole in [ROLE_AAR,ROLE_AM,ROLE_CR]) then {player addWeapon phx_loadout_bino
 
 if (pRole == ROLE_RS) then {"ACE_SpottingScope" call phx_fnc_addGear};
 if (pRole == ROLE_SNP) then {"ACE_Tripod" call phx_fnc_addGear; "ACE_RangeCard" call phx_fnc_addGear;};
+
+if (
+    pRole in [
+        ROLE_PL,
+        ROLE_SL,
+        ROLE_P,
+        ROLE_CR
+    ]
+) then {
+    switch (side player) do
+    {
+        case west: {
+            player addItem "ACE_key_west";
+        };
+        case east: {
+            player addItem "ACE_key_east";
+        };
+        case independent: {
+            player addItem "ACE_key_indp";
+        };
+    };
+};

--- a/FNF_MissionTemplate.VR/description/cfgFunctions.hpp
+++ b/FNF_MissionTemplate.VR/description/cfgFunctions.hpp
@@ -123,6 +123,7 @@ class CfgFunctions {
       class server_setupGame{};
       class radio_genFreqs{};
       class populateORBATS{};
+      class keyVehicles{};
       class lockVehicles{};
     };
     class end {

--- a/FNF_MissionTemplate.VR/description/cfgFunctions.hpp
+++ b/FNF_MissionTemplate.VR/description/cfgFunctions.hpp
@@ -123,6 +123,7 @@ class CfgFunctions {
       class server_setupGame{};
       class radio_genFreqs{};
       class populateORBATS{};
+      class lockVehicles{};
     };
     class end {
       file = "server\end";

--- a/FNF_MissionTemplate.VR/server/init/fn_keyVehicles.sqf
+++ b/FNF_MissionTemplate.VR/server/init/fn_keyVehicles.sqf
@@ -1,0 +1,14 @@
+// Key vehicles to side of safe start marker they are in 
+private _vics = entities [["Car", "Tank", "Ship", "Plane", "Helicopter"], [], false, true];
+
+{
+    _x setVariable ["ace_vehiclelock_lockSide", west, true];
+} forEach (_vics inAreaArray "bluforSafeMarker");
+
+{
+    _x setVariable ["ace_vehiclelock_lockSide", east, true];
+} forEach (_vics inAreaArray "opforSafeMarker");
+
+{
+    _x setVariable ["ace_vehiclelock_lockSide", independent, true];
+} forEach (_vics inAreaArray "indforSafeMarker");

--- a/FNF_MissionTemplate.VR/server/init/fn_lockVehicles.sqf
+++ b/FNF_MissionTemplate.VR/server/init/fn_lockVehicles.sqf
@@ -1,17 +1,14 @@
-// Setup lock state of vehicles
+// Lock unoccupied vehicles in safe start areas
 private _vics = entities [["Car", "Tank", "Ship", "Plane", "Helicopter"], [], false, true];
 
-{
-    _x setVariable ["ace_vehiclelock_lockSide", west];
-    _x setVehicleLock "LOCKED";
-} forEach (_vics inAreaArray "bluforSafeMarker");
+_vics inAreaArray "bluforSafeMarker"
+    select { count crew _x == 0 }
+    apply { _x setVehicleLock "LOCKED" };
 
-{
-    _x setVariable ["ace_vehiclelock_lockSide", east];
-    _x setVehicleLock "LOCKED";
-} forEach (_vics inAreaArray "opforSafeMarker");
+_vics inAreaArray "opforSafeMarker"
+    select { count crew _x == 0 }
+    apply { _x setVehicleLock "LOCKED" };
 
-{
-    _x setVariable ["ace_vehiclelock_lockSide", independent];
-    _x setVehicleLock "LOCKED";
-} forEach (_vics inAreaArray "indforSafeMarker");
+_vics inAreaArray "indforSafeMarker"
+    select { count crew _x == 0 }
+    apply { _x setVehicleLock "LOCKED" };

--- a/FNF_MissionTemplate.VR/server/init/fn_lockVehicles.sqf
+++ b/FNF_MissionTemplate.VR/server/init/fn_lockVehicles.sqf
@@ -1,0 +1,17 @@
+// Setup lock state of vehicles
+private _vics = entities [["Car", "Tank", "Ship", "Plane", "Helicopter"], [], false, true];
+
+{
+    _x setVariable ["ace_vehiclelock_lockSide", west];
+    _x setVehicleLock "LOCKED";
+} forEach (_vics inAreaArray "bluforSafeMarker");
+
+{
+    _x setVariable ["ace_vehiclelock_lockSide", east];
+    _x setVehicleLock "LOCKED";
+} forEach (_vics inAreaArray "opforSafeMarker");
+
+{
+    _x setVariable ["ace_vehiclelock_lockSide", independent];
+    _x setVehicleLock "LOCKED";
+} forEach (_vics inAreaArray "indforSafeMarker");

--- a/FNF_MissionTemplate.VR/server/init/fn_serverInit.sqf
+++ b/FNF_MissionTemplate.VR/server/init/fn_serverInit.sqf
@@ -17,6 +17,7 @@ call phx_fnc_server_setupGame;
 [] spawn phx_fnc_webhook_roundPrep;
 
 call phx_fnc_populateORBATs;
+call phx_fnc_lockVehicles;
 
 [{!(missionNamespace getVariable ["phx_safetyEnabled",true])}, {call phx_fnc_checkAlive}] call CBA_fnc_waitUntilAndExecute;
 [{!isNil "phx_safetyEndTime"}, {call phx_fnc_checkTime}] call CBA_fnc_waitUntilAndExecute;

--- a/FNF_MissionTemplate.VR/server/init/fn_serverInit.sqf
+++ b/FNF_MissionTemplate.VR/server/init/fn_serverInit.sqf
@@ -17,7 +17,7 @@ call phx_fnc_server_setupGame;
 [] spawn phx_fnc_webhook_roundPrep;
 
 call phx_fnc_populateORBATs;
-call phx_fnc_lockVehicles;
+call phx_fnc_keyVehicles;
 
 [{!(missionNamespace getVariable ["phx_safetyEnabled",true])}, {call phx_fnc_checkAlive}] call CBA_fnc_waitUntilAndExecute;
 [{!isNil "phx_safetyEndTime"}, {call phx_fnc_checkTime}] call CBA_fnc_waitUntilAndExecute;

--- a/FNF_MissionTemplate.VR/server/init/fn_serverSafety.sqf
+++ b/FNF_MissionTemplate.VR/server/init/fn_serverSafety.sqf
@@ -30,7 +30,9 @@ call phx_fnc_handleSafetyVics; //Make vehicles invincible until safety ends
     [] call phx_fnc_webhook_roundStart;
 
     {
-        [_x] remoteExec ["deleteMarkerLocal", -2, true];
+        if !(getMarkerColor _x isEqualTo "") then {
+            [_x] remoteExec ["deleteMarkerLocal", -2, true];
+        };
         _x setMarkerAlphaLocal 0;
     } forEach ["opforSafeMarker", "bluforSafeMarker", "indforSafeMarker"];
 
@@ -38,7 +40,9 @@ call phx_fnc_handleSafetyVics; //Make vehicles invincible until safety ends
         uiSleep 300;
         call phx_fnc_lockVehicles;
         {
-            deleteMarkerLocal _x;
+            if !(getMarkerColor _x isEqualTo "") then {
+                deleteMarkerLocal _x;
+            };
         } forEach ["opforSafeMarker", "bluforSafeMarker", "indforSafeMarker"];
     };
 

--- a/FNF_MissionTemplate.VR/server/init/fn_serverSafety.sqf
+++ b/FNF_MissionTemplate.VR/server/init/fn_serverSafety.sqf
@@ -22,16 +22,24 @@ call phx_fnc_handleSafetyVics; //Make vehicles invincible until safety ends
 }] call CBA_fnc_waitUntilAndExecute;
 
 [{f_var_mission_timer < 0}, {
-  missionNamespace setVariable ["phx_safetyEnabled",false,true];
-  missionNamespace setVariable ["phx_safetyEndTime", round CBA_missionTime, true];
-  ["SafeStartMissionStarting",["Mission starting now!"]] remoteExec ["bis_fnc_showNotification",0,false];
-  ["off"] call acex_fortify_fnc_handleChatCommand;
+    missionNamespace setVariable ["phx_safetyEnabled",false,true];
+    missionNamespace setVariable ["phx_safetyEndTime", round CBA_missionTime, true];
+    ["SafeStartMissionStarting",["Mission starting now!"]] remoteExec ["bis_fnc_showNotification",0,false];
+    ["off"] call acex_fortify_fnc_handleChatCommand;
 
-  [] call phx_fnc_webhook_roundStart;
+    [] call phx_fnc_webhook_roundStart;
 
-  {
-    if !(getMarkerColor _x isEqualTo "") then {
-      [_x] remoteExec ["deleteMarkerLocal",0,true];
+    {
+        [_x] remoteExec ["deleteMarkerLocal", -2, true];
+        _x setMarkerAlphaLocal 0;
+    } forEach ["opforSafeMarker", "bluforSafeMarker", "indforSafeMarker"];
+
+    [] spawn {
+        uiSleep 300;
+        call phx_fnc_lockVehicles;
+        {
+            deleteMarkerLocal _x;
+        } forEach ["opforSafeMarker", "bluforSafeMarker", "indforSafeMarker"];
     };
-  } forEach ["opforSafeMarker", "bluforSafeMarker", "indforSafeMarker"];
+
 }] call CBA_fnc_waitUntilAndExecute;


### PR DESCRIPTION
Vehicles inside safe start markers are locked and keyed to the side
associated with the safe start marker. Players of privileged roles are
given a key for their side. A side key may unlock/lock any vehicle
keyed to that side.

* FNF_MissionTemplate.VR/client/loadout/fn_addItems.sqf:
  - Add key to player if privileged.
* FNF_MissionTemplate.VR/description/cfgFunctions.hpp:
  - Define new function.
* FNF_MissionTemplate.VR/server/init/fn_lockVehicles.sqf:
  - Lock and key vehicles to side of safe start markers.
* FNF_MissionTemplate.VR/server/init/fn_serverInit.sqf:
  - Call new function.