### PR TITLE
Added locking of door to roof for office building

### DIFF
--- a/FNF_MissionTemplate.VR/server/init/fn_serverInit.sqf
+++ b/FNF_MissionTemplate.VR/server/init/fn_serverInit.sqf
@@ -61,6 +61,13 @@ phx_server_disconnectBodies = addMissionEventHandler ["HandleDisconnect", {
   };
 }];
 
+//Lock the door for roof access on the office building
+_triggerSize = triggerArea zoneTrigger;
+_maxSize = sqrt (((_triggerSize select 0) ^ 2) + ((_triggerSize select 1) ^ 2));
+{
+  _x setVariable ['bis_disabled_Door_6',1,true];
+} forEach (getPos zoneTrigger nearObjects ["Land_Offices_01_V1_F", _maxSize]);
+
 // Receives event when a player submits a report
 // Determines logged-in admin and sends Discord embed with contents of report and the admin @'ed
 phxAdminMessageReceiver = ["phxAdminMessageServer", {


### PR DESCRIPTION
gets the size of the zone so only locks building in safe zone then locks the door for the ladder to the roof to prevent its use

As a note with enough mashing of enhanced movement and V it is possible to glitch through the door but this takes a while and arguabley would be considered cheating