### PR TITLE
Removed ability to switch to melee in safe start

### DIFF
--- a/FNF_MissionTemplate.VR/client/safety/fn_safety.sqf
+++ b/FNF_MissionTemplate.VR/client/safety/fn_safety.sqf
@@ -47,8 +47,16 @@ phx_acePlacing = [{
   if (!phx_safetyEnabled) then {[_this select 1] call CBA_fnc_removePerFrameHandler};
 } , 0] call CBA_fnc_addPerFrameHandler;
 
+phx_switchToMeleeDisablePFH = [{
+  _tempWeaponState = weaponState player;
+  if (_tempWeaponState select 1 == "vn_melee_muzzle" || _tempWeaponState select 1 == "vn_hand_melee_muzzle") then {
+    player selectWeapon (_tempWeaponState select 0);
+  };
+}] call CBA_fnc_addPerFrameHandler;
+
 [{!phx_safetyEnabled}, {
   [phx_acePlacing] call CBA_fnc_removePerFrameHandler;
+  [phx_switchToMeleeDisablePFH] call CBA_fnc_removePerFrameHandler;
   player removeAction phx_safeStartNoFire;
   ace_advanced_throwing_enabled = true;
   player allowDamage true;


### PR DESCRIPTION
Literally cannot make this anymore seamless, prevents switching to a melee weapon in safe start by causing player to switch back to first option, since melee is always last option it makes sense to switch to first anyway