### PR TITLE
Disable typing in global/side unless staff

### DIFF
--- a/FNF_MissionTemplate.VR/client/restrictions/fn_disableTyping.sqf
+++ b/FNF_MissionTemplate.VR/client/restrictions/fn_disableTyping.sqf
@@ -1,28 +1,19 @@
-/*
-Disables typing in global, side and spectator chat if player is not staff
-*/
-
+// Configure channel permissions.
+//
+// Note that some channels are set to "voice only". This allows the
+// channels to be used for markers. Since VON is disabled in server
+// config, vanilla voice is still disabled. This gives the effect of a
+// "markers only" channel.
 [{!isNil "fnf_staffInfo"}, {
-  if ((getPlayerUID player) in fnf_staffInfo) then {
-    0 enableChannel true; //Make sure global is enabled if admin
-  } else {
-    0 enableChannel false;
-
-    //Disable chat typing if channel is side
-    [{
-      params ["_display","_handle"];
-      if (!isNull (findDisplay _display)) exitWith {
-        _handle call CBA_fnc_removePerFrameHandler;
-        phx_sideChatRestrict = (findDisplay _display) displayAddEventHandler ["KeyDown", "if (_this select 1 in actionKeys 'Chat' && currentChannel == 1) then { true } else { false };"];
-      };
-    }, 1, 46] call CBA_fnc_addPerFrameHandler; //Mission display
-
-    [{
-      params ["_display","_handle"];
-      if (!isNull (findDisplay _display)) exitWith {
-        _handle call CBA_fnc_removePerFrameHandler;
-        phx_spectatorChatRestrict = (findDisplay _display) displayAddEventHandler ["KeyDown", "if (_this select 1 in actionKeys 'Chat') then { true } else { false };"];
-      };
-    }, 1, 60000] call CBA_fnc_addPerFrameHandler; //ACE spectator display
-  };
+    if ((getPlayerUID player) in fnf_staffInfo) then {
+        0 enableChannel true;          // Global
+        1 enableChannel true;          // Side
+    } else {
+        0 enableChannel false;         // Global
+        1 enableChannel [false, true]; // Side
+    };
+    2 enableChannel false;             // Command
+    3 enableChannel true;              // Group
+    4 enableChannel true;              // Vehicle
+    5 enableChannel true;              // Direct
 }] call CBA_fnc_waitUntilAndExecute;


### PR DESCRIPTION
For non-staff, side channel is a "markers only" channel. See comment
in fn_disableTyping.sqf.