### PR TITLE
Allows Zues to be accessed after death

### DIFF
--- a/FNF_MissionTemplate.VR/client/init/fn_clientInit.sqf
+++ b/FNF_MissionTemplate.VR/client/init/fn_clientInit.sqf
@@ -55,6 +55,12 @@ player addEventHandler ["Killed", {
   };
 }];
 
+player addEventHandler ["Respawn", {
+	params ["_unit", "_corpse"];
+	_unit allowDamage false;
+	_unit remoteExec ["hideObjectGlobal",2];
+	[player] join createGroup civilian;
+}];
 
 //Marking
 [] execVM "client\icons\QS_icons.sqf";

--- a/FNF_MissionTemplate.VR/client/spectator/fn_spectatorInit.sqf
+++ b/FNF_MissionTemplate.VR/client/spectator/fn_spectatorInit.sqf
@@ -95,3 +95,9 @@ phx_spectatorPrevVisibleCtrls = [];
     };
   };
 }] call CBA_fnc_addPerFrameHandler;
+
+//Hide players also in spectator
+[{
+  _playersToBlacklist = call ace_spectator_fnc_players;
+  [allPlayers, _playersToBlacklist] call ace_spectator_fnc_updateUnits;
+}] call CBA_fnc_addPerFrameHandler;

--- a/FNF_MissionTemplate.VR/description/definitions.hpp
+++ b/FNF_MissionTemplate.VR/description/definitions.hpp
@@ -4,7 +4,7 @@ enableDebugConsole = 1;
 
 respawn = 3;
 respawnDialog = 0;
-respawndelay = 99999;
+respawndelay = 5;
 respawnOnStart = -1;
 respawnTemplates[] = {};
 joinUnassigned = 1;


### PR DESCRIPTION
Note, i have no idea how this will react with OCAP since player side is changed to civilian to prevent map markers being shown to friendlys

another note, spectators _may_ be able to see dead players in debug but hopefully this is accounted for (Testing needed)