### PR TITLE
Adds number of alive players per side for players in spectator

### DIFF
--- a/FNF_MissionTemplate.VR/client/misc/admin/functions/fn_respawnPlayer.sqf
+++ b/FNF_MissionTemplate.VR/client/misc/admin/functions/fn_respawnPlayer.sqf
@@ -94,6 +94,9 @@ _out pushBack format["ACTION: %1", "RespawnPlayer"];
           _timer = _timer - 1;
         };
 
+        // Turn off drawing number of alive players per side 
+        ("FNF_spectatorUI" call BIS_fnc_rscLayer) cutText ["", "PLAIN"];
+
         // respawn procedure
         setPlayerRespawnTime -1;
         uiSleep 1;

--- a/FNF_MissionTemplate.VR/client/spectator/fn_init.sqf
+++ b/FNF_MissionTemplate.VR/client/spectator/fn_init.sqf
@@ -111,4 +111,7 @@ fnf_spectatorPrevVisibleCtrls = [];
   };
 }] call CBA_fnc_addPerFrameHandler;
 
+// Start drawing number of alive players per side
+("FNF_spectatorUI" call BIS_fnc_rscLayer) cutRsc ["alivePlayers", "PLAIN"];
+
 true

--- a/FNF_MissionTemplate.VR/client/ui/RscTitlesDisplay.hpp
+++ b/FNF_MissionTemplate.VR/client/ui/RscTitlesDisplay.hpp
@@ -118,4 +118,48 @@ class RscTitles {
       };
     };
   };
+
+  //("FNF_spectatorUI" call BIS_fnc_rscLayer) cutRsc ["alivePlayers", "PLAIN"];	// show
+  //("FNF_spectatorUI" call BIS_fnc_rscLayer) cutText ["", "PLAIN"];				    // remove
+  class alivePlayers {
+    idd = -1;
+    duration = 1e+011;
+    onLoad = "uiNamespace setVariable ['FNF_spectatorUI', _this #0]; FNF_spectator = true;";
+    onUnload = "FNF_spectator = false";
+
+    class Controls {
+      class alivePlayersCountWest: RscText {
+        idc = -1;
+        style = ST_CENTER;
+        onLoad = "[(_this #0), west] call FNF_UI_fnc_spectatorHandler;";
+        x   = 0.20 * safezoneW + safezoneX;
+        y   = 0.97 * safezoneH + safezoneY;
+        w   = 0.03 * safezoneW;
+        h   = 0.03 * safezoneH;
+        colorBackground[] = {0,0,0,0};
+      };
+
+      class alivePlayersCountEast: RscText {
+        idc = -1;
+        style = ST_CENTER;
+        onLoad = "[(_this #0), east] call FNF_UI_fnc_spectatorHandler;";
+        x   = 0.23 * safezoneW + safezoneX;
+        y   = 0.97 * safezoneH + safezoneY;
+        w   = 0.03 * safezoneW;
+        h   = 0.03 * safezoneH;
+        colorBackground[] = {0,0,0,0};
+      };
+
+      class alivePlayersCountRes: RscText {
+        idc = -1;
+        style = ST_CENTER;
+        onLoad = "[(_this #0), resistance] call fnf_ui_fnc_spectatorHandler;";
+        x   = 0.26 * safezoneW + safezoneX;
+        y   = 0.97 * safezoneH + safezoneY;
+        w   = 0.03 * safezoneW;
+        h   = 0.03 * safezoneH;
+        colorBackground[] = {0,0,0,0};
+      };
+    };
+  };
 };

--- a/FNF_MissionTemplate.VR/client/ui/spectator/fn_spectatorHandler.sqf
+++ b/FNF_MissionTemplate.VR/client/ui/spectator/fn_spectatorHandler.sqf
@@ -1,0 +1,18 @@
+params ["_control", "_side"];
+
+[_control, _side] spawn {
+	params ["_control", "_side"];
+	_color = [_side] call BIS_fnc_sideColor;
+	_control ctrlSetBackgroundColor _color;
+
+	while {FNF_spectator} do {
+		_count = ({alive _x && isPlayer _x} count units _side);
+		if (_count > 0) then {   
+            _control ctrlShow true;
+            _control ctrlSetText (str _count);
+        } else {
+            _control ctrlShow false;
+        };
+		sleep 1;
+	};
+};

--- a/FNF_MissionTemplate.VR/description/cfgFunctions.hpp
+++ b/FNF_MissionTemplate.VR/description/cfgFunctions.hpp
@@ -256,6 +256,10 @@ class CfgFunctions {
       class genPolylineFromMarkers{};
       class removeShadedPolygon{};
     };
+    class spectator {
+      file = "client\ui\spectator";
+      class spectatorHandler {};
+    };
   };
   class fnf_server {
     class initServer {


### PR DESCRIPTION
Adds a simple GUI  that shows the number of alive players for Blue/Red/Greenfor.
Drawing starts when the player is moved into a spectator.
Drawing ends when the player is respawned.

Partially solves https://github.com/FridayNightFight/FNF/issues/148 number of dead players is irrelevant IMO.

How it looks: 
(The space there is reserved for Redfor, might be possible to move Greenfor if Redfor is not present/fully dead)
![image](https://user-images.githubusercontent.com/23197934/230577562-0f02c67c-a387-4f96-84e4-00ab06bcf109.png)
