### PR TITLE
Added numbers of players for spectators

### DIFF
--- a/FNF_Mission_Template.VR/Client/Spectator/fn_initSpectatorSlot.sqf
+++ b/FNF_Mission_Template.VR/Client/Spectator/fn_initSpectatorSlot.sqf
@@ -13,3 +13,5 @@
 
 params["_modules"]
 
+// Start spectator interface rendering
+("FNF_spectatorUI" call BIS_fnc_rscLayer) cutRsc ["spectatorSideNumbers", "PLAIN"];

--- a/FNF_Mission_Template.VR/Client/Spectator/fn_spectatorUIhandler.sqf
+++ b/FNF_Mission_Template.VR/Client/Spectator/fn_spectatorUIhandler.sqf
@@ -1,0 +1,71 @@
+/*
+	Author: ilbinek
+
+	Description:
+		Start handling of spectator UI
+
+	Parameter(s):
+		None
+
+	Returns:
+		None
+*/
+
+#define FNF_RSC_TEXT_1 	6001
+#define FNF_RSC_TEXT_2 	6002
+#define FNF_RSC_TEXT_3 	6003
+#define FNF_RSC_TEXT_4 	6004
+[
+	{
+    private _dialog = uiNameSpace getVariable ["FNF_spectatorUI", displayNull];
+    if (!isNull _dialog) then {
+      private _nbr = FNF_RSC_TEXT_1;
+      {
+        private _side = _x;
+        private _count = ({alive _x && isPlayer _x && !(_x getVariable ["ACE_isUnconscious", false])} count units _side); // cout all players of a side that are NOT unconscious
+        if (_count > 0) then {
+          private _control = _dialog displayCtrl _nbr;
+          private _color = _side call BIS_fnc_sideColor;
+          _control ctrlSetBackgroundColor _color;
+          _control ctrlSetText str(_count);
+          _control ctrlCommit 0;
+          _nbr = _nbr + 1;
+        };
+      } forEach [west, east, resistance];
+      // Handle uncounscious players
+      // _nbr is already set to the first available control
+      private _count = ({alive _x && isPlayer _x && (_x getVariable ["ACE_isUnconscious", false])} count allPlayers); // count all players that are unconscious
+      if (_count > 0) then {
+        private _control = _dialog displayCtrl _nbr;
+        private _color = civilian call BIS_fnc_sideColor; // Use civilian color for unconscious players
+        _control ctrlSetBackgroundColor _color;
+        _control ctrlSetText str(_count);
+        _control ctrlCommit 0;
+        _nbr = _nbr + 1;
+      };
+
+      // Secondary check, that will clear all controls if player is alive and stop the PFH - does not work for spectator slots (sideLogic)
+      if (alive player && side player != sideLogic) then {
+        _nbr = FNF_RSC_TEXT_1;
+        FNF_spectator = false;
+        ("FNF_spectatorUI" call BIS_fnc_rscLayer) cutText ["", "PLAIN"];
+      };
+
+      // Clear the rest of the controls showing
+      while {_nbr <= FNF_RSC_TEXT_4} do {
+        private _control = _dialog displayCtrl _nbr;
+        private _color = [0, 0, 0, 0]; // Use civilian color for unconscious players
+        _control ctrlSetBackgroundColor _color;
+        _control ctrlSetText "";
+        _control ctrlCommit 0;
+        _nbr = _nbr + 1;
+      };
+    };
+	}, 	// Code to be executed
+	1, 	// Once a second
+	[], // No parameters
+	{}, // No start function
+	{}, // No end function
+	{true}, // No run condition
+	{!FNF_spectator} // Will delete PFH when FNF_spectator is set to false
+] call CBA_fnc_createPerFrameHandlerObject;

--- a/FNF_Mission_Template.VR/Client/Spectator/fn_spectatorUIhandler.sqf
+++ b/FNF_Mission_Template.VR/Client/Spectator/fn_spectatorUIhandler.sqf
@@ -51,6 +51,11 @@
         ("FNF_spectatorUI" call BIS_fnc_rscLayer) cutText ["", "PLAIN"];
       };
 
+      // Clear all controls if spectator UI is not visible
+      if (!ace_spectator_uiVisible) then {
+        _nbr = FNF_RSC_TEXT_1;
+      };
+
       // Clear the rest of the controls showing
       while {_nbr <= FNF_RSC_TEXT_4} do {
         private _control = _dialog displayCtrl _nbr;

--- a/FNF_Mission_Template.VR/Client/Spectator/fn_startSpectator.sqf
+++ b/FNF_Mission_Template.VR/Client/Spectator/fn_startSpectator.sqf
@@ -20,3 +20,5 @@ if (!isNull _lastDamage) then {
 } else {
   [2, player] call ace_spectator_fnc_setCameraAttributes;
 };
+
+("FNF_spectatorUI" call BIS_fnc_rscLayer) cutRsc ["spectatorSideNumbers", "PLAIN"];

--- a/FNF_Mission_Template.VR/Description/Functions.hpp
+++ b/FNF_Mission_Template.VR/Description/Functions.hpp
@@ -94,6 +94,7 @@ class CfgFunctions
       file = "Client\Spectator";
       class startSpectator {};
       class initSpectatorSlot {};
+      class spectatorUIhandler {};
     };
     class hidingZones
     {

--- a/FNF_Mission_Template.VR/Description/UiDescriptions.hpp
+++ b/FNF_Mission_Template.VR/Description/UiDescriptions.hpp
@@ -1,3 +1,8 @@
+#define FNF_RSC_TEXT_1 	6001
+#define FNF_RSC_TEXT_2 	6002
+#define FNF_RSC_TEXT_3 	6003
+#define FNF_RSC_TEXT_4 	6004
+
 class RscTitles {
   class timeleftStructText {
     idd = 9913;
@@ -36,6 +41,58 @@ class RscTitles {
             underline = false;
             size = "1.7";
         };
+      };
+    };
+  };
+
+  // Start: ("FNF_spectatorUI" call BIS_fnc_rscLayer) cutRsc ["spectatorSideNumbers", "PLAIN"];
+  // End:   ("FNF_spectatorUI" call BIS_fnc_rscLayer) cutText ["", "PLAIN"];
+  class spectatorSideNumbers {
+    idd = 696969;
+    duration = 1e+011; 
+	  movingenable = true;
+    onLoad = "uiNamespace setVariable ['FNF_spectatorUI', _this #0]; FNF_spectator = true; call FNF_ClientSide_fnc_spectatorUIhandler;";
+	  onUnload = "FNF_spectator = false; uiNamespace setVariable ['FNF_spectatorUI', nil];";
+
+    class controls {
+      class FNFalive1 {
+        idc = FNF_RSC_TEXT_1;
+        style = 2;
+        sizeEx = 0.045;
+        x = safeZoneX + safezoneW * 0.17;
+        y = safeZoneY + safeZoneH * 0.95;
+        w = 0.05 * safezoneW;
+        h = 0.05 * safezoneH;
+        colorBackground[] = {0,0,0,0};
+        deletable = 0;
+        fade = 0;
+        access = 0;
+        type = 0;
+        colorText[] = {1,1,1,1};
+        text = "";
+        fixedWidth = 0;
+        shadow = 1;
+        colorShadow[] = {0,0,0,0.5};
+        font = "RobotoCondensed";
+        linespacing = 1;
+        tooltipColorText[] = {1,1,1,1};
+        tooltipColorBox[] = {1,1,1,1};
+        tooltipColorShade[] = {0,0,0,0.65};
+      };
+
+      class FNFalive2: FNFalive1 {
+        idc = FNF_RSC_TEXT_2;
+        x = safeZoneX + safezoneW * 0.22;
+      };
+
+      class FNFalive3: FNFalive1 {
+        idc = FNF_RSC_TEXT_3;
+        x = safeZoneX + safezoneW * 0.27;
+      };
+
+      class FNFalive4: FNFalive1 {
+        idc = FNF_RSC_TEXT_4;
+        x = safeZoneX + safezoneW * 0.32;
       };
     };
   };


### PR DESCRIPTION
Spectator UI for framework version 4.
Now uses CBA PFH for updates.

Once respawn is added, there shouldn't be any changes needed, as the PFH checks if the player is alive and will stop the spectator UI on its own.

Unconscious players are shown in purple/civil color.
Updates once a second.
Is able to handle 3 side missions

Also takes care of [#148](https://github.com/FridayNightFight/FNF/issues/148)